### PR TITLE
Depend on puppetlabs/apache

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -56,6 +56,10 @@
       "version_requirement": ">=5.1.0 <6.0.0"
     },
     {
+      "name": "puppetlabs/apache",
+      "version_requirement": ">=3.0.0 <4.0.0"
+    },
+    {
       "name": "puppet/archive",
       "version_requirement": ">=2.2.0 <3.0.0"
     },


### PR DESCRIPTION
Most of the examples require puppetlabs/apache so make it a dependency

Signed-off-by: Samuli Seppänen <samuli.seppanen@puppeteers.fi>