### PR TITLE
Add Vagrant support

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,38 @@ with:
 ```
 $ bundle exec rake test
 $ PUPPET_INSTALL_TYPE=agent PUPPET_INSTALL_VERSION=x.y.z bundle exec rake beaker:<nodeset>
-```
 
 Please log issues or pull requests at
 [github](https://github.com/bodgit/puppet-wordpress).
+
+You can use [Vagrant](https://www.vagrantup.com) and [Virtualbox](https://www.virtualbox.org)
+for testing and developing this module. Currently the Vagrantfile creates a CentOS 7 VM
+("wordpress") and runs provisioning steps that
+
+* Install Puppet 5 from Puppetlabs
+* Fetch this module's dependencies with [librarian-puppet](https://librarian-puppet.com) based on metadata.json
+* Runs a Puppet manifest (wordpress.pp) with "puppet apply"
+
+All usernames and passwords are "vagrant".
+
+To create or start the VM:
+
+    $ vagrant up
+
+To (re)provision the VM, usually to test new puppet code:
+
+    $ vagrant provision
+
+To shut down the VM:
+
+    $ vagrant halt
+
+To destroy the VM:
+
+    $ vagrant destroy
+
+If you want to test some particular Wordpress setup you can create a custom Puppet manifest and point
+your Vagrantfile to it. After the VM has been created you can comment out the prepare.sh
+provisioning step in the Vagranfile to speed up Puppet code testing.
+
+See [Vagrant documentation](https://www.vagrantup.com/docs/index.html) for details.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  config.vm.define "wordpress" do |box|
+    box.vm.box = "centos/7"
+    box.vm.box_version = "1804.02"
+    box.vm.hostname = "wordpress.local"
+    box.vm.network "private_network", ip: "192.168.71.100"
+    box.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+    box.vm.provision "shell" do |s|
+      s.path = "vagrant/prepare.sh"
+      s.args = ["-n", "wordpress", "-f", "redhat", "-o", "el-7", "-b", "/home/vagrant"]
+    end
+    box.vm.provision "shell", inline: "puppet apply --modulepath /home/vagrant/modules /vagrant/vagrant/wordpress.pp"
+    box.vm.provider "virtualbox" do |vb|
+      vb.gui = false
+      vb.memory = 1024
+    end
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -56,6 +56,10 @@
       "version_requirement": ">=5.1.0 <6.0.0"
     },
     {
+      "name": "puppetlabs/apache",
+      "version_requirement": ">=3.0.0 <4.0.0"
+    },
+    {
       "name": "puppet/archive",
       "version_requirement": ">=2.2.0 <3.0.0"
     },

--- a/vagrant/prepare.sh
+++ b/vagrant/prepare.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+#
+# Preparations required prior to "puppet apply".
+
+usage() {
+    echo
+    echo "Usage: prepare.sh -n module_name -f osfamily -o os"
+    echo
+    echo "Options:"
+    echo " -n   Name of the module that includes this script. Used to copy"
+    echo "      the module code to the modulepath."
+    echo " -f   Operating system family for this Vagrant VM. Valid values are"
+    echo "      redhat and debian. This determines the logic to use when"
+    echo "      installing Puppet on the nodes."
+    echo " -o   Operating system version. For Debian derivatives use the"
+    echo "      codename (e.g. stretch or xenial). For RedHat derivatives"
+    echo "      use the osname-osversion scheme (e.g. el-7). For details"
+    echo "      see Puppet yum/apt repository documentation"
+    echo " -b   Base directory for dependency Puppet modules installed by"
+    echo "      librarian-puppet."
+    exit 1
+}
+
+
+# Parse the options
+
+# We are run without parameters -> usage
+if [ "$1" == "" ]; then
+        usage
+fi
+
+while getopts "n:f:o:b:h" options; do
+  case $options in
+        n ) THIS_MODULE=$OPTARG;;
+        f ) OSFAMILY=$OPTARG;;
+        o ) OS=$OPTARG;;
+        b ) BASEDIR=$OPTARG;;
+        h ) usage;;
+        \? ) usage;;
+        * ) usage;;
+  esac
+done
+
+CWD=`pwd`
+
+install_puppet() {
+    if [ $OSFAMILY = 'redhat' ]; then
+        rpm -ivh https://yum.puppetlabs.com/puppet5/puppet5-release-$OS.noarch.rpm
+        yum install -y puppet-agent yum-utils git
+        yum-config-manager --save --setopt=puppetlabs-pc1.skip_if_unavailable=true
+    elif [ $OSFAMILY = 'debian' ]; then
+        wget https://apt.puppetlabs.com/puppet5-release-$OS.deb -O puppet5-release-$OS.deb
+        dpkg -i puppet5-release-$OS.deb
+        apt-get update
+        apt-get -y install puppet-agent git
+    else
+        echo "ERROR: unsupported value ${OSFAMILY} for option -f!"
+        usage
+    fi
+}
+
+install_puppet
+
+export PATH=$PATH:/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin
+
+# Install librarian-puppet with Puppetlabs' gem and not a system gem
+/opt/puppetlabs/puppet/bin/gem install librarian-puppet
+
+# Install dependency modules with librarian-puppet
+cd $BASEDIR
+mkdir -p modules
+rm -f $BASEDIR/metadata.json
+ln -s /vagrant/metadata.json
+librarian-puppet install
+
+# Copy over this in-development module to modules
+# directory
+rm -f modules/${THIS_MODULE}
+ln -s /vagrant modules/${THIS_MODULE}
+
+cd $CWD

--- a/vagrant/wordpress.pp
+++ b/vagrant/wordpress.pp
@@ -1,0 +1,45 @@
+class { '::mysql::server':
+  root_password => 'vagrant',
+}
+
+include ::php
+include ::wordpress
+
+::wordpress::instance { '/srv/wordpress':
+  owner       => 'apache',
+  db_name     => 'wordpress',
+  db_user     => 'wordpress',
+  db_password => 'vagrant',
+}
+
+class { '::apache':
+  default_mods  => false,
+  default_vhost => false,
+}
+
+include ::apache::mod::dir
+include ::apache::mod::php
+
+::apache::vhost { 'wordpress':
+  docroot     => '/srv/wordpress',
+  directories => [
+    {
+      'path'           => '/srv/wordpress',
+      'allow_override' => [
+        'FileInfo',
+      ],
+      'directoryindex' => 'index.php',
+      'options'        => [
+        'FollowSymlinks',
+      ],
+    },
+    {
+      'path'       => '\\.php$',
+      'provider'   => 'filesmatch',
+      'sethandler' => 'application/x-httpd-php',
+    },
+  ],
+  port        => 80,
+  servername  => 'wordpress.local',
+  require     => ::Wordpress::Instance['/srv/wordpress'],
+}


### PR DESCRIPTION
This PR adds Vagrant support that is useful when testing or developing this module. The default provisioning step is taken from README.md with minor modifications. Adding puppetlabs/apache as a dependency to metadata.json is required because otherwise puppet-librarian would not load that module and catalog compilation in the provisioning step would fail.