### PR TITLE
Make use of bodgit-php optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@
 #
 # @since 1.0.0
 class wordpress (
+  Boolean                         $manage_php = true,
   Hash[String, Hash[String, Any]] $instances = {},
 ) {
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,8 @@
 # @!visibility private
 class wordpress::install {
 
-  include ::php::extension::mysql
-  include ::php::extension::xml
+  if $::wordpress::manage_php {
+    include ::php::extension::mysql
+    include ::php::extension::xml
+  }
 }


### PR DESCRIPTION
This puppet-wordpress module is only very lightly integrated with [bodgit-php](https://github.com/bodgit/puppet-php). Make the use of that particular PHP module optional without changing the default behavior.